### PR TITLE
Update holykpk#blessRNG3.tex

### DIFF
--- a/mathematical-analysis/sem3/holykpk#blessRNG3.tex
+++ b/mathematical-analysis/sem3/holykpk#blessRNG3.tex
@@ -2379,7 +2379,7 @@ $(2)$ уже сразу $< \varepsilon$, т. к. $n - (N_1 - 1)$ очевидн�
     \item $\mathcal{P} \subset 2^X$ --- полукольцо, если: 
         \begin{enumerate}
             \item $\O \in \mathcal{P}$
-            \item $\forall A, B \in \mathcal{P}: A \cup B \in \mathcal{P}$
+            \item $\forall A, B \in \mathcal{P}: A \cap B \in \mathcal{P}$
             \item $\forall A, B \in \mathcal{P}: \exists D_1, D_2, \ldots, D_n$ --- дизъюнктные, такие что: $A \setminus B = \bigsqcup_{i} D_i$
         \end{enumerate}
         


### PR DESCRIPTION
Во второй аксиоме полукольца требуется пересечении, а не объединение