### PR TITLE
Update holykpk#blessRNG3.tex

### DIFF
--- a/mathematical-analysis/sem3/holykpk#blessRNG3.tex
+++ b/mathematical-analysis/sem3/holykpk#blessRNG3.tex
@@ -1232,7 +1232,7 @@ $\Phi(U(x^0)) = W, \Phi(x^0) = w_0$. Рассмотрим функцию $\widet
 
 \subsubsection{Формулировка критерия Больцано--Коши для равномерной сходимости}
 
-\[f_n \rsh{X} f \Leftrightarrow \forall \varepsilon > 0 \dbl \exists n \dbl \forall p \dbl \forall x \in X \dbl \left|f_{n + p}(x) - f_n(x)\right| < \varepsilon \]
+\[f_n \rsh{X} f \Leftrightarrow \forall \varepsilon > 0 \dbl \exists N \dbl \forall n > N \dbl \forall p \dbl \forall x \in X \dbl \left|f_{n + p}(x) - f_n(x)\right| < \varepsilon \]
 
 \subsubsection{Равномерная сходимость функционального ряда}
 
@@ -1254,7 +1254,7 @@ $S_N(x) = \sum_{k = 1}^N f_k(x)$ --- частичная сумма
 
 \subsubsection{Формулировка критерия Больцано--Коши для равномерной сходимости рядов}
 
-\[\sum_{k = 1}^{\infty} f_k \rshe \Leftrightarrow \forall \varepsilon > 0 \dbl \exists n \dbl \forall p \dbl \forall x \in E \dbl \left|\sum_{k = n}^{n + p} f_k(x)\right| < \varepsilon \]
+\[\sum_{k = 1}^{\infty} f_k \rshe \Leftrightarrow \forall \varepsilon > 0 \dbl \exists N \dbl \forall n > N \dbl \forall p \dbl \forall x \in E \dbl \left|\sum_{k = n}^{n + p} f_k(x)\right| < \varepsilon \]
 
 \subsubsection{Признак Абеля равномерной сходимости функционального ряда}
 


### PR DESCRIPTION
В формулировках критериев Больцано-Коши для равномерной сходимости была пропущена, часть формулировки